### PR TITLE
Fixed some missing shelfmarks

### DIFF
--- a/items/32_15a1.jsonld.json
+++ b/items/32_15a1.jsonld.json
@@ -37,7 +37,7 @@
   },
   "schema:identifier": [
     "ark:/87293/d3t14tt6b",
-    "D-405, Box:Folder 32:13-17"
+    "ark:/87287/d7r94j/D-405/Box:32+Folder:13-17"
   ],
   "schema:image": {
     "@id": "@base:/media/images/32_15a1.tif"

--- a/items/32_25a.jsonld.json
+++ b/items/32_25a.jsonld.json
@@ -36,7 +36,7 @@
     "@id": "@base:/32_25a.tif"
   },
   "schema:identifier": [
-    "D-405, Box:Folder 32:24-25",
+    "ark:/87287/d7r94j/D-405/Box:32+Folder:24-25",
     "ark:/87293/d3jh3d69q"
   ],
   "schema:license": {

--- a/items/32_27a1.jsonld.json
+++ b/items/32_27a1.jsonld.json
@@ -34,7 +34,7 @@
   },
   "schema:identifier": [
     "ark:/87293/d3dr2pd62",
-    "D-405, Box:Folder 32:26-29"
+    "ark:/87287/d7r94j/D-405/Box:32+Folder:26-29"
   ],
   "schema:image": {
     "@id": "@base:/media/images/32_27a1.tif"

--- a/items/32_5a1.jsonld.json
+++ b/items/32_5a1.jsonld.json
@@ -40,7 +40,7 @@
     "@value": "1900~"
   },
   "schema:identifier": [
-    "D-405, Box:Folder 32:5-6",
+    "ark:/87287/d7r94j/D-405/Box:32+Folder:5-6",
     "ark:/87293/d35717s6w"
   ],
   "schema:image": {

--- a/items/32_5b1.jsonld.json
+++ b/items/32_5b1.jsonld.json
@@ -37,7 +37,7 @@
     "@value": "1900~"
   },
   "schema:identifier": [
-    "D-405, Box:Folder 32:5-6",
+    "ark:/87287/d7r94j/D-405/Box:32+Folder:5-6",
     "ark:/87293/d3ws8hr2h"
   ],
   "schema:image": {

--- a/items/32_5c1.jsonld.json
+++ b/items/32_5c1.jsonld.json
@@ -38,7 +38,7 @@
   },
   "schema:identifier": [
     "ark:/87293/d3n87344q",
-    "D-405, Box:Folder 32:5-6"
+    "ark:/87287/d7r94j/D-405/Box:32+Folder:5-6"
   ],
   "schema:image": {
     "@id": "@base:/media/images/32_5c1.tif"

--- a/items/32_5d1.jsonld.json
+++ b/items/32_5d1.jsonld.json
@@ -40,7 +40,7 @@
     "@value": "1900~"
   },
   "schema:identifier": [
-    "D-405, Box:Folder 32:5-6",
+    "ark:/87287/d7r94j/D-405/Box:32+Folder:5-6",
     "ark:/87293/d3cr5nh6t"
   ],
   "schema:image": {

--- a/items/32_6a1.jsonld.json
+++ b/items/32_6a1.jsonld.json
@@ -37,7 +37,7 @@
     "@value": "1900~"
   },
   "schema:identifier": [
-    "D-405, Box:Folder 32:5-6",
+    "ark:/87287/d7r94j/D-405/Box:32+Folder:5-6",
     "ark:/87293/d34746w74"
   ],
   "schema:image": {

--- a/items/32_6b1.jsonld.json
+++ b/items/32_6b1.jsonld.json
@@ -38,7 +38,7 @@
   },
   "schema:identifier": [
     "ark:/87293/d3vt1gv2t",
-    "D-405, Box:Folder 32:5-6"
+    "ark:/87287/d7r94j/D-405/Box:32+Folder:5-6"
   ],
   "schema:image": {
     "@id": "@base:/media/images/32_6b1.tif"

--- a/items/32_6c1.jsonld.json
+++ b/items/32_6c1.jsonld.json
@@ -38,7 +38,7 @@
   },
   "schema:identifier": [
     "ark:/87293/d3m902741",
-    "D-405, Box:Folder 32:5-6"
+    "ark:/87287/d7r94j/D-405/Box:32+Folder:5-6"
   ],
   "schema:image": {
     "@id": "@base:/media/images/32_6c1.tif"

--- a/items/36_11a.jsonld.json
+++ b/items/36_11a.jsonld.json
@@ -33,7 +33,7 @@
     "@id": "@base:/36_11a.tif"
   },
   "schema:identifier": [
-    "D-405, Box:Folder 36:8-12",
+    "ark:/87287/d7r94j/D-405/Box:36+Folder:8-12",
     "ark:/87293/d32b8vh13"
   ],
   "schema:license": {

--- a/items/45_3a1.jsonld.json
+++ b/items/45_3a1.jsonld.json
@@ -30,7 +30,7 @@
     "@id": "@base:/media/images"
   },
   "schema:identifier": [
-    "D-405, Box:Folder 45:3 ",
+    "ark:/87287/d7r94j/D-405/Box:45+Folder:3",
     "ark:/87293/d3vm43240"
   ],
   "schema:image": {


### PR DESCRIPTION
The previous method  of changing shelmarks missed some, I now used.

```bash
for i in items/*.jsonld.json; do
 cp $i tmp.json; 
 jq 'if has("schema:identifier") then
     .["schema:identifier"] |= map(
       if test("^D-405") then
         sub("^(D-405), Box:Folder (?<b>[0-9]+):(?<f>[0-9-]+)$"; "ark:/87287/d7r94j/D-405/Box:\(.b)+Folder:\(.f)")
       else
         .
       end
     )
     else . end ' tmp.json > $i;
done
rm tmp.json
```